### PR TITLE
Create backup script with example crontab

### DIFF
--- a/bin/backup.sh
+++ b/bin/backup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+#script to pull all git repos on puppet-community so we don't have a jenkins incident
+# */15 * * * * ./plumbing/bin/backup.sh
+
+git_root="https://github.com/"
+repos_url="https://api.github.com/users/puppet-community/repos "
+
+for repo in `curl -s $repos_url | jq '.[] | .full_name' | tr -d \"`
+do
+    repo_short=`echo $repo | cut -d "/" -f 2`
+
+    if ! [ -d $repo_short ]; then
+        git clone -q $git_root/$repo
+    fi
+    cd $repo_short
+    git pull -q
+    cd ..
+
+done


### PR DESCRIPTION
The jenkins project accidentally lost all their history when
an errant script force-pushed nothing to all their repos. This
runs on one of Spencer's servers to give us a backup in case
this or something else weird happens.